### PR TITLE
Refactor CheckoutSessionCreateParams & allow promotion code for session creation

### DIFF
--- a/demo-app/web/index.php
+++ b/demo-app/web/index.php
@@ -6,8 +6,8 @@ use Monolog\Level;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use PatternSeek\StripeCheckoutFacade\Checkout;
-use PatternSeek\StripeCheckoutFacade\ValueTypes\CheckoutLocale;
 use PatternSeek\StripeCheckoutFacade\ValueTypes\CheckoutMode;
+use PatternSeek\StripeCheckoutFacade\ValueTypes\CheckoutSessionCreateParams;
 use PatternSeek\StripeCheckoutFacade\ValueTypes\CustomerEmailOrId;
 use PatternSeek\StripeCheckoutFacade\ValueTypes\LineItem;
 use Psr\Log\LoggerInterface;
@@ -94,16 +94,13 @@ try{
 function checkoutStart( LoggerInterface $log, $apiPublicKey, $apiSecretKey, CustomerEmailOrId $customerIdentification, $priceId, $returnUrl ): string
 {
     $checkout = new Checkout($apiSecretKey, $log);
-    $sessionClientSecret = $checkout->createCheckoutSession(
-        customeridentification: $customerIdentification,
-        lineItems: [
-            new LineItem($priceId, 1)
-        ], 
-        mode: CheckoutMode::SubscriptionOrMixed, 
-        locale: CheckoutLocale::auto,
-        useStripeTax: true,
-        returnUrl: $returnUrl 
+    $createParams = new CheckoutSessionCreateParams(
+        customerIdentification: $customerIdentification,
+        mode: CheckoutMode::SubscriptionOrMixed,
+        returnUrl: $returnUrl
     );
+    $createParams->lineItems[] = new LineItem($priceId, 1);
+    $sessionClientSecret = $checkout->createCheckoutSession($createParams);
 
     ob_start();
     // uses $apiPublicKey and $sessionClientSecret

--- a/src/ValueTypes/CheckoutSessionCreateParams.php
+++ b/src/ValueTypes/CheckoutSessionCreateParams.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ *
+ * © 2024 Tolan Blundell.  All rights reserved.
+ * <tolan@patternseek.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace PatternSeek\StripeCheckoutFacade\ValueTypes;
+
+/**
+ * Represents the parameters required to create a Stripe Checkout session.
+ */
+class CheckoutSessionCreateParams
+{
+    public readonly CustomerEmailOrId $customerIdentification;
+    public readonly CheckoutMode $mode;
+    public readonly string $returnUrl;
+    /**
+     * @var array<LineItem>
+     */
+    public array $lineItems = [];
+    public CheckoutLocale $locale = CheckoutLocale::auto;
+    public bool $useStripeTax = true;
+    public bool $allowPromotionCodes = true;
+
+    /**
+     * Constructs a set of parameters for creating a Stripe Checkout session.
+     *
+     * @param CustomerEmailOrId $customerIdentification Whether to identify the customer by email or Stripe customer ID.
+     * @param CheckoutMode      $mode                   The mode of the checkout session.
+     * @param string            $returnUrl              The URL to redirect to after the checkout session is completed.
+     */
+    public function __construct(CustomerEmailOrId $customerIdentification, CheckoutMode $mode, string $returnUrl)
+    {
+        if (false === \mb_strstr($returnUrl, '{CHECKOUT_SESSION_ID}')) {
+            $errMsg = 'returnUrl must contain {CHECKOUT_SESSION_ID}.';
+            $errMsg .= ' See https://docs.stripe.com/payments/checkout/custom-redirect-behavior#return-url';
+            throw new \InvalidArgumentException($errMsg);
+        }
+
+        $this->customerIdentification = $customerIdentification;
+        $this->mode = $mode;
+        $this->returnUrl = $returnUrl;
+    }
+
+    /**
+     * Converts this object to an array suitable for passing to the Stripe API.
+     *
+     * @return array<string,mixed> The array of parameters.
+     */
+    public function toApiParams(): array
+    {
+        if (\count($this->lineItems) === 0) {
+            throw new \InvalidArgumentException('At least one line item must be added to the checkout session.');
+        }
+
+        $firstLineItem = $this->lineItems[0];
+        $lineItems = $this->lineItems;
+        if ($firstLineItem instanceof LineItem) {
+            $lineItems = LineItem::objectArrayToStringArray($lineItems);
+        }
+        $params = [
+            'ui_mode' => 'embedded',
+            'line_items' => $lineItems,
+            'mode' => $this->mode->value,
+            'locale' => $this->locale->value,
+            'return_url' => $this->returnUrl,
+        ];
+        $paramKey = match ($this->customerIdentification->type) {
+            CustomerIdentifierType::Email => 'customer_email',
+            CustomerIdentifierType::StripeCustomerId => 'customer',
+        };
+        $params[$paramKey] = $this->customerIdentification->value();
+        if ($this->useStripeTax) {
+            $params['automatic_tax'] = ['enabled' => true];
+        }
+        if ($this->allowPromotionCodes) {
+            $params['allow_promotion_codes'] = true;
+        }
+
+        return $params;
+    }
+}

--- a/tests/CheckoutTest.php
+++ b/tests/CheckoutTest.php
@@ -15,15 +15,13 @@ namespace PatternSeek\StripeCheckoutFacade;
 use Exception;
 use Monolog\Handler\TestHandler;
 use PatternSeek\StripeCheckoutFacade\Checkout;
-use PatternSeek\StripeCheckoutFacade\ValueTypes\CheckoutLocale;
 use PatternSeek\StripeCheckoutFacade\ValueTypes\CheckoutMode;
+use PatternSeek\StripeCheckoutFacade\ValueTypes\CheckoutSessionCreateParams;
 use PatternSeek\StripeCheckoutFacade\ValueTypes\CustomerEmailOrId;
 use PatternSeek\StripeCheckoutFacade\ValueTypes\LineItem;
 use PHPUnit\Framework\TestCase;
 use Monolog\Level;
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Stripe\Checkout\Session;
 
 class CheckoutTest extends TestCase
 {
@@ -50,16 +48,13 @@ class CheckoutTest extends TestCase
     {
 
         $checkout = new Checkout($this->config['apiSecretKey'], $this->log);
-        $sessionClientSecret = $checkout->createCheckoutSession(
-            customeridentification: CustomerEmailOrId::email($this->config['customerEmail']),
-            lineItems: [
-                new LineItem($this->config['priceId'], 1)
-            ],
+        $createParams = new CheckoutSessionCreateParams(
+            customerIdentification: CustomerEmailOrId::email($this->config['customerEmail']),
             mode: CheckoutMode::SubscriptionOrMixed,
-            locale: CheckoutLocale::auto,
-            useStripeTax: true,
             returnUrl: $this->config['checkoutReturnUrl']
         );
+        $createParams->lineItems[] = new LineItem($this->config['priceId'], 1);
+        $sessionClientSecret = $checkout->createCheckoutSession($createParams);
         $this->assertNotEmpty($sessionClientSecret);
     }
 
@@ -70,16 +65,13 @@ class CheckoutTest extends TestCase
     {
 
         $checkout = new Checkout($this->config['apiSecretKey'], $this->log);
-        $sessionClientSecret = $checkout->createCheckoutSession(
-            customeridentification: CustomerEmailOrId::stripeCustomerId($this->config['customerId']),
-            lineItems: [
-                new LineItem($this->config['priceId'], 1)
-            ],
+        $createParams = new CheckoutSessionCreateParams(
+            customerIdentification: CustomerEmailOrId::stripeCustomerId($this->config['customerId']),
             mode: CheckoutMode::SubscriptionOrMixed,
-            locale: CheckoutLocale::auto,
-            useStripeTax: true,
             returnUrl: $this->config['checkoutReturnUrl']
         );
+        $createParams->lineItems[] = new LineItem($this->config['priceId'], 1);
+        $sessionClientSecret = $checkout->createCheckoutSession($createParams);
         $this->assertNotEmpty($sessionClientSecret);
     }
 
@@ -91,17 +83,13 @@ class CheckoutTest extends TestCase
         $this->expectException(Exception::class);
         
         $checkout = new Checkout($this->config['apiSecretKey'], $this->log);
-        $sessionClientSecret = $checkout->createCheckoutSession(
-            customeridentification: CustomerEmailOrId::stripeCustomerId($this->config['customerId']),
-            lineItems: [
-                new LineItem($this->config['priceId'], 1)
-            ],
+        $createParams = new CheckoutSessionCreateParams(
+            customerIdentification: CustomerEmailOrId::stripeCustomerId($this->config['customerId']),
             mode: CheckoutMode::SubscriptionOrMixed,
-            locale: CheckoutLocale::auto,
-            useStripeTax: true,
-            returnUrl: "http://url.without.return.page.com/"
+            returnUrl: 'http://url.without.return.page.com/'
         );
-        
+        $createParams->lineItems[] = new LineItem($this->config['priceId'], 1);
+        $checkout->createCheckoutSession($createParams);
     }
 
     /**
@@ -112,17 +100,13 @@ class CheckoutTest extends TestCase
         $this->expectException(Exception::class);
 
         $checkout = new Checkout($this->config['apiSecretKey'], $this->log);
-        $sessionClientSecret = $checkout->createCheckoutSession(
-            customeridentification: CustomerEmailOrId::stripeCustomerId($this->config['customerId']),
-            lineItems: [
-                new LineItem("INVALID PRICE ID", 1)
-            ],
+        $createParams = new CheckoutSessionCreateParams(
+            customerIdentification: CustomerEmailOrId::stripeCustomerId($this->config['customerId']),
             mode: CheckoutMode::SubscriptionOrMixed,
-            locale: CheckoutLocale::auto,
-            useStripeTax: true,
             returnUrl: $this->config['checkoutReturnUrl']
         );
-
+        $createParams->lineItems[] = new LineItem("INVALID PRICE ID", 1);
+        $checkout->createCheckoutSession($createParams);
     }
 
     


### PR DESCRIPTION
- Introduce param `allow_promotion_codes`.
- Refactor `createCheckoutSession()` to accept `CheckoutSessionCreateParams`, or else there are many arguments.